### PR TITLE
vimc-4298 accomodate all possible orderly.server statuses

### DIFF
--- a/orderlyweb_api/result_models.py
+++ b/orderlyweb_api/result_models.py
@@ -4,8 +4,8 @@ class ReportStatusResult:
         self.version = response_data["version"]
         self.output = response_data["output"]
         self.success = self.status == "success"
-        self.fail = "error" in self.status.lower()
-        self.finished = self.success or self.fail
+        self.finished = self.status.lower() not in ["running", "queued"]
+        self.fail = self.finished and not self.success
 
 
 class VersionDetails:

--- a/test/unit/test_report_status_result.py
+++ b/test/unit/test_report_status_result.py
@@ -7,8 +7,20 @@ test_result_success = ReportStatusResult({"status": "success",
 test_result_running = ReportStatusResult({"status": "running",
                                           "version": None, "output": {}})
 
-test_result_error = ReportStatusResult({"status": "RuntimeError",
+test_result_runtimeerror = ReportStatusResult({"status": "RuntimeError",
+                                               "version": None, "output": {}})
+
+test_result_error = ReportStatusResult({"status": "error",
                                         "version": None, "output": {}})
+
+test_result_killed = ReportStatusResult({"status": "killed",
+                                         "version": None, "output": {}})
+
+test_result_queued = ReportStatusResult({"status": "queued",
+                                         "version": None, "output": {}})
+
+test_result_unknown = ReportStatusResult({"status": "unknown",
+                                          "version": None, "output": {}})
 
 
 def test_status():
@@ -25,17 +37,29 @@ def test_output():
 
 def test_success():
     assert test_result_success.success
+    assert not test_result_queued.success
     assert not test_result_running.success
     assert not test_result_error.success
+    assert not test_result_runtimeerror.success
+    assert not test_result_killed.success
+    assert not test_result_unknown.success
 
 
 def test_fail():
     assert not test_result_success.fail
     assert not test_result_running.fail
+    assert not test_result_queued.fail
     assert test_result_error.fail
+    assert test_result_runtimeerror.fail
+    assert test_result_killed.fail
+    assert test_result_unknown.fail
 
 
 def test_finished():
-    assert test_result_success.finished
+    assert not test_result_queued.finished
     assert not test_result_running.finished
+    assert test_result_success.finished
     assert test_result_error.finished
+    assert test_result_runtimeerror.finished
+    assert test_result_killed.finished
+    assert test_result_unknown.finished


### PR DESCRIPTION
I've gone for treating all statuses other than "running" and "queued" as terminal ones, including "unknown" and anything else that isn't recognised. And interpreted "fail" to mean anything other than "success" - so a killed report is still a failed one. 