### PR TITLE
Increment version number for new published version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "pytest"]
 
 setup(name="orderlyweb-api",
-      version="0.0.7",
+      version="0.0.8",
       description="Python client for OrderlyWeb API",
       long_description=long_description,
       classifiers=[


### PR DESCRIPTION
This just increments the version number for the latest published version: https://pypi.org/project/orderlyweb-api/0.0.8/

This contains changes from https://github.com/vimc/orderly-web-py/pull/5 and https://github.com/vimc/orderly-web-py/pull/6