### PR TITLE
vimc-4588 Fix for new orderly server interface

### DIFF
--- a/scripts/orderly-web.yml
+++ b/scripts/orderly-web.yml
@@ -5,13 +5,20 @@ network: montagu_default
 volumes:
   orderly: orderly_volume
   proxy_logs: orderly_web_proxy_logs
-
+  redis: orderly_web_redis_data
+## Redis configuration
+redis:
+  image:
+    name: redis
+    tag: "5.0"
+  volume: orderly_web_redis_data
 ## Orderly configuration
 orderly:
   image:
     repo: vimc
     name: orderly.server
     tag: master
+    worker_name: orderly.server
   initial:
     source: clone
     url: https://github.com/vimc/orderly-demo

--- a/test/integration/test_orderly_web_api.py
+++ b/test/integration/test_orderly_web_api.py
@@ -40,7 +40,7 @@ def test_kill_report():
     key = api.run_report('minimal', {}, 500)
     api.kill_report(key)
     result = api.report_status(key)
-    assert result.status == "killed"
+    assert result.status == "interrupted"
 
 
 def test_run_report():
@@ -84,9 +84,7 @@ def test_report_status():
     key = api.run_report('minimal', {}, 500)
     result = api.report_status(key)
     assert result.status == "queued"
-    assert result.version is None
-    assert len(result.output["stderr"]) == 0
-    assert len(result.output["stdout"]) > 0
+    assert result.output is None
     assert not result.success
     assert not result.fail
     assert not result.finished

--- a/test/unit/test_report_status_result.py
+++ b/test/unit/test_report_status_result.py
@@ -2,7 +2,7 @@ from orderlyweb_api.result_models import ReportStatusResult
 
 test_result_success = ReportStatusResult({"status": "success",
                                           "version": "test-version",
-                                          "output": {"stdout": ["test-out"]}})
+                                          "output": ["test-out"]})
 
 test_result_running = ReportStatusResult({"status": "running",
                                           "version": None, "output": {}})
@@ -32,7 +32,7 @@ def test_version():
 
 
 def test_output():
-    assert test_result_success.output["stdout"] == ["test-out"]
+    assert test_result_success.output == ["test-out"]
 
 
 def test_success():


### PR DESCRIPTION
- Provides a valid config for the new orderly web deploy requirements (redis volume and image, and worker specified)
- Fixes tests which assumed previous status output values (stderr and stdout)