### PR TITLE
vimc-4590 Provide new POST body format to run endpoint

### DIFF
--- a/orderlyweb_api/orderly_web_api.py
+++ b/orderlyweb_api/orderly_web_api.py
@@ -16,7 +16,7 @@ class OrderlyWebAPI:
 
     def run_report(self, report, params, timeout=600):
         url = 'reports/{}/run/?timeout={}'.format(report, timeout)
-        result = self.post(url, str(params))
+        result = self.post(url, str({'params': params}))
         return result['key']
 
     def publish_report(self, name, version):

--- a/orderlyweb_api/orderly_web_api.py
+++ b/orderlyweb_api/orderly_web_api.py
@@ -2,6 +2,7 @@ from orderlyweb_api.result_models import ReportStatusResult, VersionDetails
 
 from orderlyweb_api.orderly_web_response_error import OrderlyWebResponseError
 import requests
+import json
 
 
 class OrderlyWebAPI:
@@ -16,7 +17,7 @@ class OrderlyWebAPI:
 
     def run_report(self, report, params, timeout=600):
         url = 'reports/{}/run/?timeout={}'.format(report, timeout)
-        result = self.post(url, str({'params': params}))
+        result = self.post(url, json.dumps({'params': params}))
         return result['key']
 
     def publish_report(self, name, version):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "pytest"]
 
 setup(name="orderlyweb-api",
-      version="0.0.9",
+      version="0.0.10",
       description="Python client for OrderlyWeb API",
       long_description=long_description,
       classifiers=[

--- a/test/integration/test_orderly_web_api.py
+++ b/test/integration/test_orderly_web_api.py
@@ -105,3 +105,20 @@ def test_run_report_to_completion():
     assert not result.fail
     assert len(result.version) > 0
     assert result.output is None
+
+
+def test_run_report_with_params_to_completion():
+    api = OrderlyWebAPI(base_url, montagu_token)
+    key = api.run_report('other', {'nmin': 0}, 500)
+    finished = False
+    timeout = datetime.now() + timedelta(minutes=1)
+    while not finished and datetime.now() < timeout:
+        time.sleep(0.5)
+        result = api.report_status(key)
+        finished = result.finished
+    assert result.status == "success"
+    assert result.finished
+    assert result.success
+    assert not result.fail
+    assert len(result.version) > 0
+    assert result.output is None

--- a/test/unit/test_orderly_web_api.py
+++ b/test/unit/test_orderly_web_api.py
@@ -44,7 +44,7 @@ def test_run_report():
         assert key == "test-key"
 
         request = m.request_history[0]
-        assert request.body == "{'p1': 'v1', 'p2': 2}"
+        assert request.body == "{'params': {'p1': 'v1', 'p2': 2}}"
 
 
 def test_run_report_error():

--- a/test/unit/test_orderly_web_api.py
+++ b/test/unit/test_orderly_web_api.py
@@ -44,7 +44,7 @@ def test_run_report():
         assert key == "test-key"
 
         request = m.request_history[0]
-        assert request.body == "{'params': {'p1': 'v1', 'p2': 2}}"
+        assert request.body == "{\"params\": {\"p1\": \"v1\", \"p2\": 2}}"
 
 
 def test_run_report_error():


### PR DESCRIPTION
Provide parameters in a property in the body rather than whole body. 

We haven't supported `ref` or `instance` in the python client, and we still don't - just fixing params to be correctly provided. 